### PR TITLE
fix: only create a promise if no callback is passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,15 +22,22 @@
  **/
 
 "use strict";
- 
+
 const createCallback = (method, context) => {
     return function() {
-        const args = Array.prototype.slice.call(arguments);   
+        const args = Array.prototype.slice.call(arguments);
+        const lastIndex = args.length - 1;
+        const lastArg = args && args.length > 0 ? args[lastIndex] : null;
+        const cb = typeof lastArg === 'function' ? lastArg : null;
 
-        return new Promise((solve, reject) => {
+        if (cb) {
+            return method.apply(context, args);
+        }
+
+        return new Promise((resolve, reject) => {
             args.push((err, val) => {
                 if (err) return reject(err);
-                solve(val);
+                resolve(val);
             });
 
             method.apply(context, args);
@@ -51,6 +58,6 @@ module.exports = (methods, options) => {
 
         return obj;
     }
-    
+
     return createCallback(methods, options.context || methods);
 }

--- a/test.js
+++ b/test.js
@@ -1,15 +1,15 @@
 // Require the dependencies
 var assert = require("assert");
 var promisify = require(".");
-      
-// Start the tests      
-describe('Test without arguments', function() {    
+
+// Start the tests
+describe('Test without arguments', function() {
     var asyncMethod = function(callback) {
         callback(null, "Hello world!");
     };
 
     var fn = promisify(asyncMethod);
-    
+
     it("should assert the string to match the original (callback version)", function(done) {
         fn(function(err, str) {
             assert.equal(null, err);
@@ -17,7 +17,7 @@ describe('Test without arguments', function() {
             done();
         });
     });
-    
+
     it("should assert the string to match the original (promise version)", function(done) {
         fn()
         .then(function(str) {
@@ -29,21 +29,21 @@ describe('Test without arguments', function() {
         .then(done);
     });
 });
-    
-describe('Sum two arguments, using the err and value args', function() {    
+
+describe('Sum two arguments, using the err and value args', function() {
     var asyncMethod = function(num1, num2, callback) {
         callback(num1, num2);
     };
 
     var fn = promisify(asyncMethod);
-    
+
     it("should assert the num to be equally to 15", function(done) {
         fn(3, 12, function(err, value) {
             assert.equal(15, err + value);
             done();
         });
     });
-    
+
     it("should assert the promise to the exact numbers", function(done) {
         fn(3, 12)
         .then(function(value) {
@@ -56,20 +56,34 @@ describe('Sum two arguments, using the err and value args', function() {
     });
 });
 
-describe('Promisify a native Node module', function() {    
+describe('Promisify a native Node module', function() {
     var fs = promisify(require("fs"));
     var crypto = require("crypto");
-    
-    it("should assert the hashed content of the LICENSE file", function(done) {
-        fs.readFile("./LICENSE")
+
+    it("should assert the hashed content of the LICENSE file", function() {
+        return fs.readFile("./LICENSE")
         .then(function(content) {
             var hash = crypto
                     .createHash("sha1")
                     .update(content)
                     .digest("hex");
-                    
-            assert.equal("f007af74b2183ca8700b6f691c67d5ccc06d7b64", hash);            
-            done();
+
+            assert.equal("504af7b48f92e3f9d6d96cf8913bfa60514eefde", hash);
         });
     });
+});
+
+describe('callback handling', function() {
+  it('should throw error if using a callback', function(done) {
+    var failMe = promisify(function(msg, cb) {
+      throw new Error(msg);
+    });
+
+    try {
+      failMe('fail', function () {});
+    } catch (err) {
+      assert.equal(err.message, 'fail')
+      done();
+    }
+  });
 });


### PR DESCRIPTION
Otherwise if using a callback, and the method called throws an error it gets swallowed as shown by the added test.
